### PR TITLE
fix failing AppSideNavigation test

### DIFF
--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
@@ -217,13 +217,11 @@ describe("GlobalSideNav", () => {
     ];
     renderWithBrowserRouter(<AppSideNavigation />, { route: "/", state });
 
-    const controllerLink = screen.getByRole("listitem", {
-      name: "Controllers",
+    const controllerLink = screen.getByRole("link", {
+      name: /Controllers/i,
     });
     const warningIcon = within(controllerLink).getByTestId("warning-icon");
-    expect(warningIcon).toHaveClass(
-      "p-navigation--item-icon p-icon--security-warning-grey"
-    );
+    expect(warningIcon).toHaveClass("p-icon--security-warning-grey");
   });
 
   it("does not display a warning icon next to controllers if vault is fully configured", () => {
@@ -233,7 +231,7 @@ describe("GlobalSideNav", () => {
     ];
     renderWithBrowserRouter(<AppSideNavigation />, { route: "/", state });
 
-    const controllerLink = screen.getByRole("listitem", {
+    const controllerLink = screen.getByRole("link", {
       name: "Controllers",
     });
     expect(
@@ -248,7 +246,7 @@ describe("GlobalSideNav", () => {
     ];
     renderWithBrowserRouter(<AppSideNavigation />, { route: "/", state });
 
-    const controllerLink = screen.getByRole("listitem", {
+    const controllerLink = screen.getByRole("link", {
       name: "Controllers",
     });
     expect(


### PR DESCRIPTION
## Done

- fix failing AppSideNavigation test

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
