### PR TITLE
fix assets-path

### DIFF
--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -13,4 +13,4 @@ $increase-font-size-on-larger-screens: false;
 $side-panel-z-index: 101;
 $side-navigation-z-index: 103;
 $application-layout--breakpoint-side-nav-expanded: $breakpoint-xx-large;
-$assets-path: "~/assets/fonts/";
+$assets-path: "/assets/fonts/";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
       },
     ],
   },
+  build: {
+    outDir: "build",
+  },
   server: {
     port: 8401,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12060,7 +12060,7 @@ sass@1.57.1:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-sass@^1.58.1:
+sass@1.58.1:
   version "1.58.1"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.58.1.tgz#17ab0390076a50578ed0733f1cc45429e03405f6"
   integrity sha512-bnINi6nPXbP1XNRaranMFEBZWUfdW/AF16Ql5+ypRxfTvCRTTKrLsMIakyDcayUt2t/RZotmL4kgJwNH5xO+bg==
@@ -13428,12 +13428,12 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vite-plugin-env-compatible@^1.1.1:
+vite-plugin-env-compatible@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vite-plugin-env-compatible/-/vite-plugin-env-compatible-1.1.1.tgz#2e11b059a5f3e8fc609d6a4bba84ca497081ee20"
   integrity sha512-4lqhBWhOzP+SaCPoCVdmpM5cXzjKQV5jgFauxea488oOeElXo/kw6bXkMIooZhrh9q7gclTl8en6N9NmnqUwRQ==
 
-vite-tsconfig-paths@^4.0.5:
+vite-tsconfig-paths@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-4.0.5.tgz#c7c54e2cf7ccc5e600db565cecd7b368a1fa8889"
   integrity sha512-/L/eHwySFYjwxoYt1WRJniuK/jPv+WGwgRGBYx3leciR5wBeqntQpUE6Js6+TJemChc+ter7fDBKieyEWDx4yQ==


### PR DESCRIPTION
## Done

- [fix assets-path](https://github.com/ndv99/maas-ui/commit/4abc8595de09e0a6dbe8506e2387ba9706fd0c9e)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
